### PR TITLE
Add server-side attributes tab to Device Profile and Asset Profile

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/ControllerConstants.java
+++ b/application/src/main/java/org/thingsboard/server/controller/ControllerConstants.java
@@ -1661,7 +1661,7 @@ public class ControllerConstants {
             "Platform creates an audit log event about entity time series updates with action type 'TIMESERIES_UPDATED' that includes an error stacktrace.";
 
     protected static final String ENTITY_ATTRIBUTE_SCOPES_TEMPLATE = " List of possible attribute scopes depends on the entity type: " +
-            "\n\n * SERVER_SCOPE - supported for all entity types;" +
+            "\n\n * SERVER_SCOPE - supported for all entity types, including device profiles and asset profiles;" +
             "\n * SHARED_SCOPE - supported for devices";
     protected static final String ENTITY_SAVE_ATTRIBUTE_SCOPES = ENTITY_ATTRIBUTE_SCOPES_TEMPLATE + ".\n\n";
     protected static final String ENTITY_GET_ATTRIBUTE_SCOPES = ENTITY_ATTRIBUTE_SCOPES_TEMPLATE +

--- a/ui-ngx/src/app/modules/home/pages/asset-profile/asset-profile-tabs.component.html
+++ b/ui-ngx/src/app/modules/home/pages/asset-profile/asset-profile-tabs.component.html
@@ -16,6 +16,13 @@
 
 -->
 @if (entity && !isEdit) {
+  <mat-tab label="{{ 'attribute.attributes' | translate }}" #attributesTab="matTab">
+    <tb-attribute-table [defaultAttributeScope]="attributeScopes.SERVER_SCOPE"
+                        [active]="attributesTab.isActive"
+                        [entityId]="entity.id"
+                        [entityName]="entity.name">
+    </tb-attribute-table>
+  </mat-tab>
   @if (authUser.authority === authorities.TENANT_ADMIN) {
     <mat-tab label="{{ 'entity.type-calculated-fields' | translate }}" #calculatedFieldsTab="matTab">
       <tb-calculated-fields-table [active]="calculatedFieldsTab.isActive" [entityId]="entity.id" [entityName]="entity.name" [ownerId]="entity.tenantId"/>

--- a/ui-ngx/src/app/modules/home/pages/device-profile/device-profile-tabs.component.html
+++ b/ui-ngx/src/app/modules/home/pages/device-profile/device-profile-tabs.component.html
@@ -48,6 +48,15 @@
       </div>
     }
   </mat-tab>
+  @if (!isEdit) {
+    <mat-tab label="{{ 'attribute.attributes' | translate }}" #attributesTab="matTab">
+      <tb-attribute-table [defaultAttributeScope]="attributeScopes.SERVER_SCOPE"
+                          [active]="attributesTab.isActive"
+                          [entityId]="entity.id"
+                          [entityName]="entity.name">
+      </tb-attribute-table>
+    </mat-tab>
+  }
   @if (authUser.authority === authorities.TENANT_ADMIN && !isEdit) {
     <mat-tab label="{{ 'entity.type-calculated-fields' | translate }}" #calculatedFieldsTab="matTab">
       <tb-calculated-fields-table [active]="calculatedFieldsTab.isActive" [entityId]="entity.id" [entityName]="entity.name" [ownerId]="entity.tenantId"/>


### PR DESCRIPTION
## Summary
- Adds an Attributes tab (SERVER_SCOPE only) to Device Profile and Asset Profile detail pages
- Follows the same pattern used by Asset entity's attributes tab (`tb-attribute-table` component)
- Updates API docs in `ControllerConstants` to mention profile support

Closes thingsboard/thingsboard#9695

## Test plan
- [ ] Open a Device Profile → verify Attributes tab appears (not in edit mode)
- [ ] Add/edit/delete a server-side attribute on a Device Profile
- [ ] Open an Asset Profile → verify Attributes tab appears (not in edit mode)
- [ ] Add/edit/delete a server-side attribute on an Asset Profile
- [ ] Verify attribute scope selector is locked to SERVER_SCOPE (read-only)
- [ ] Verify tabs don't appear in edit mode